### PR TITLE
fix: add Dockerfile for Cloud Run deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.env
+.venv
+venv
+node_modules
+.DS_Store
+docs
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+ENV PORT=8080
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD streamlit run app.py --server.port=${PORT} --server.address=0.0.0.0 --server.headless=true


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` at repo root so the Cloud Build trigger for `researchagent-us` can build the image.
- Adds `.dockerignore` to keep the build context small.

## Why
Cloud Build was failing with:
```
unable to prepare context: unable to evaluate symlinks in Dockerfile path:
lstat /workspace/Dockerfile: no such file or directory
```
Trigger expects a Dockerfile at the repository root; none existed.

## Dockerfile
- `python:3.11-slim` base
- Installs `requirements.txt` (already contains `streamlit>=1.50.0`)
- Runs Streamlit on `${PORT}` (default 8080), bound to `0.0.0.0`, headless

## Test plan
- [ ] Merge to `main`
- [ ] Cloud Build trigger for `researchagent-us` runs and succeeds
- [ ] Cloud Run revision deploys and serves Streamlit on port 8080